### PR TITLE
ensure payment.receiver is proxy_fund_app address

### DIFF
--- a/demos/trampoline/app.py
+++ b/demos/trampoline/app.py
@@ -21,7 +21,8 @@ def fund():
         app_create.on_completion() == OnComplete.NoOp,
         app_create.application_id() == Int(0),
         pay.type_enum() == TxnType.Payment,
-        pay.amount() > min_bal,  # min bal of 0.1A
+        pay.amount() >= min_bal,  # min bal of 0.1A
+        pay.receiver() == Global.current_application_address(),
         pay.close_remainder_to() == Global.zero_address(),
         pay_proxy.type_enum() == TxnType.ApplicationCall,
         pay_proxy.on_completion() == OnComplete.NoOp,
@@ -39,7 +40,7 @@ def fund():
         InnerTxnBuilder.SetFields(
             {
                 TxnField.type_enum: TxnType.Payment,
-                TxnField.amount: min_bal,
+                TxnField.amount: pay.amount(),
                 TxnField.receiver: addr.value(),
                 TxnField.fee: Int(0),  # make caller pay
             }

--- a/demos/trampoline/demo.py
+++ b/demos/trampoline/demo.py
@@ -33,10 +33,16 @@ def demo():
                 fund_proxy_app, fund_app_addr
             )
         )
-
-        # set the fee to 2x min fee, this allows the inner app call to proceed even though the app address is not funded
+        # get tx suggested params
         sp = client.suggested_params()
-        sp.fee = sp.min_fee * 3
+
+        # Fund to proxy app
+        proxy_fund_tx = PaymentTxn(addr, sp, fund_app_addr, int(1e5))
+        txid = client.send_transaction(proxy_fund_tx.sign(pk))
+        wait_for_confirmation(client, txid, 1)
+
+        # set the fee to 4x min fee, user will cover all fee
+        sp.fee = sp.min_fee * 4
 
         # Create atc to handle method calling for us
         atc = AtomicTransactionComposer()


### PR DESCRIPTION
- Make sure payment receiver is proxy fund address. 
- Small change in trampoline demo flow