### PR TITLE
Example like ECDSA.recover from OpenZeppelin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .venv/
 __pycache__/
 .vscode/
+.idea

--- a/README.md
+++ b/README.md
@@ -4,11 +4,14 @@ Demo for AVM 1.1 features
 
 ## Sandbox 
 
-A sandbox running `master` branch with a NETWORK_TEMPLATE setting that has its ConsensusProtocol set to `future` must be used.
+A sandbox running `release` branch.
 
-The provided `config.dev` will suite this need, `./sandbox up dev` to start it (you may need to sandbox down/sandbox clean first)
+The provided `config.release` will suite this need, `./sandbox up release` to start it (you may need to sandbox down/sandbox clean first)
 
 ## Python Requirements
+
+Python 3.10 is required.
+If Ubuntu 20.04, macOS 12, or HomeBrew on macOS is used, manual installation of Python 3.10 is required.
 
 Once you've cloned this repo down, cd to this directory and run
 
@@ -26,6 +29,8 @@ With the sandbox running and the venv requirements in place, you should be able 
 python -m demos.c2c.demo
 # or
 python -m demos.c2c_max_depth.demo
+# or
+python -m demos.eth_ecdsa_recover.demo
 # or
 python -m demos.new_ops.demo
 # or
@@ -58,11 +63,29 @@ Useless example that shows the max depth limitation of 8 inner app calls.
     demo.py - contains python logic to create the applications and call them
 
 
+# eth_ecdsa_recover
+
+This example shows how to get the equivalent of OpenZeppelin ECDSA.recover for long 65-byte Ethereum signatures
+(https://docs.openzeppelin.com/contracts/2.x/api/cryptography#ECDSA-recover-bytes32-bytes-)
+Short 64-byte Ethereum signatures require some changes to the code.
+This can be used in applications requiring some compatibility with Ethereum.
+For pure Algorand applications, ed25519 is strongly recommended instead of ecdsa.
+
+Like the other examples, this example has *NOT* been audited and *MUST NOT* be used in production code.
+If this example is used in production code, a full audit is necessary due to the nature of this example
+(use of cryptography).
+
+## c2c max depth files
+
+    app.py  - contains approval and clear programs in pyteal
+    demo.py - contains python logic to create the applications and call them
+
+
 # Trampoline
 
 Fund app address during create
 
-Simple example to demonstrate the use of an existing application to dynamically create a transaction to pay an account who's address is unknown at transaction signing time. 
+Simple example to demonstrate the use of an existing application to dynamically create a transaction to pay an account whose address is unknown at transaction signing time. 
 
 This is especially useful in the case that an application creator wants to create an application _and_ fund it within a single (grouped) transaction.
 
@@ -93,6 +116,8 @@ Demonstate how to use the newly available opcodes
 NEED MORE POWER
 
 While evaluating a contract, different code paths may require additional ops to complete successfully. This demo shows a way to check the current budget and request additional buget in the form of an application call transaction.
+
+Note that current versions of PyTeal include such a logic using the `OpUp` function.
 
 ## op up files
 

--- a/demos/eth_ecdsa_recover/app.py
+++ b/demos/eth_ecdsa_recover/app.py
@@ -1,0 +1,100 @@
+import os
+
+# WARNING: This code has not been audited
+# DO NOT USE IN PRODUCTION
+
+from pyteal import *
+
+
+@Subroutine(TealType.bytes)
+def eth_ecdsa_recover(hash_value, signature):
+    """
+    Equivalent of OpenZeppelin ECDSA.recover for long 65-byte Ethereum signatures
+    https://docs.openzeppelin.com/contracts/2.x/api/cryptography#ECDSA-recover-bytes32-bytes-
+    Short 64-byte Ethereum signatures require some changes to the code
+
+    Return a 20-byte Ethereum address
+
+    Note: Unless compatibility with Ethereum or another system is necessary, we highly recommend using
+    ed25519_verify instead of ecdsa on Algorand
+
+    WARNING: This code has NOT been audited
+    DO NOT USE IN PRODUCTION
+    """
+    opup = OpUp(OpUpMode.OnCall)  # we need more budget to be able to run
+
+    r = Extract(signature, Int(0), Int(32))
+    s = Extract(signature, Int(32), Int(32))
+    # The recovery ID is shifted by 27 on Ethereum
+    # For non-Ethereum signatures, remove the -27 on the line below
+    v = Btoi(Extract(signature, Int(64), Int(1))) - Int(27)
+
+    return Seq(
+        Assert(Len(signature) == Int(65)),
+        Assert(Len(hash_value) == Int(32)),
+        opup.ensure_budget(Int(2500)),  # need 2000 for EcdsaRecover, adding a bit more for margin
+        # The following two asserts are to prevent malleability
+        # like in
+        # https://github.com/OpenZeppelin/openzeppelin-contracts/blob/5fbf494511fd522b931f7f92e2df87d671ea8b0b/contracts/utils/cryptography/ECDSA.sol#L153
+        Assert(BytesLe(s, Bytes("base16", "0x7FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF5D576E7357A4501DDFE92F46681B20A0"))),
+        Assert(Or(v == Int(0), v == Int(1))),
+        EcdsaRecover(EcdsaCurve.Secp256k1, hash_value, v, r, s).outputReducer(
+            # Ethereum concatenate the x and y part of the public key
+            # and then applies Keccak256 and take the last 20 bytes
+            lambda x, y: Extract(Keccak256(Concat(x, y)), Int(12), Int(20))
+        )
+    )
+
+
+def approval():
+    """
+    This smart contract, once created, has a single non-ABI-compliant noop method call
+    that takes two application arguments:
+      hash, signature
+    and logs the result of the function ECDSA.recover(hash, signature)
+    as written in OpenZeppelin
+        https://docs.openzeppelin.com/contracts/2.x/api/cryptography#ECDSA-recover-bytes32-bytes-
+    (65-byte signatures only)
+    """
+    return Cond(
+        [Txn.application_id() == Int(0), Approve()],
+        [
+            Txn.on_completion() == OnComplete.DeleteApplication,
+            Return(Txn.sender() == Global.creator_address()),
+        ],
+        [
+            Txn.on_completion() == OnComplete.UpdateApplication,
+            Return(Txn.sender() == Global.creator_address()),
+        ],
+        [Txn.on_completion() == OnComplete.CloseOut, Approve()],
+        [Txn.on_completion() == OnComplete.OptIn, Approve()],
+        [
+            Txn.on_completion() == OnComplete.NoOp,
+            Seq(
+                Log(eth_ecdsa_recover(Txn.application_args[0], Txn.application_args[1])),
+                Approve()
+            )
+        ],
+    )
+
+
+def clear():
+    return Approve()
+
+
+def get_approval():
+    return compileTeal(approval(), mode=Mode.Application, version=6)
+
+
+def get_clear():
+    return compileTeal(clear(), mode=Mode.Application, version=6)
+
+
+if __name__ == "__main__":
+    path = os.path.dirname(os.path.abspath(__file__))
+
+    with open(os.path.join(path, "approval.teal"), "w") as f:
+        f.write(get_approval())
+
+    with open(os.path.join(path, "clear.teal"), "w") as f:
+        f.write(get_clear())

--- a/demos/eth_ecdsa_recover/demo.py
+++ b/demos/eth_ecdsa_recover/demo.py
@@ -1,0 +1,147 @@
+import sys
+import traceback
+import base64
+
+from Cryptodome.Hash import keccak
+from algosdk.future.transaction import *
+
+from .app import get_approval, get_clear
+from ..utils import get_accounts, create_app, delete_app
+
+client = algod.AlgodClient("a" * 64, "http://localhost:4001")
+
+
+def call_application_eth_ecdsa_recover(
+        acct: tuple[any, str], app_id: int, message: bytes, signature: bytes
+) -> bytes:
+    """
+    Call the application with hash, signature
+    See comment of app.approval() to see what it does
+    hash is Keccak256(message)
+    """
+    addr, pk = acct
+
+    m = keccak.new(digest_bits=256)
+    m.update(message)
+    hash = m.digest()
+
+    sp = client.suggested_params()
+
+    actxn = ApplicationCallTxn(
+        addr,
+        sp,
+        app_id,
+        OnComplete.NoOpOC,
+        app_args=[hash, signature]
+    )
+
+    # We increase the fee due to the opup mechanism
+    # https://pyteal.readthedocs.io/en/stable/opup.html
+    # the choice of the fee is hihgly non-optimal
+    # The reader is tasked to figure out the right fee
+    actxn.fee = actxn.fee * (256 + 1)
+
+    # Group and sign
+    stxn = actxn.sign(pk)
+    txid = stxn.transaction.get_txid()
+
+    # Ship it
+    client.send_transaction(stxn)
+
+    # Get back the logs
+    results = [wait_for_confirmation(client, txid, 4)]
+    return get_logs_recursive(results)[0]
+
+
+def test_application_eth_ecdsa_recover(
+        acct: tuple[any, str], app_id: int, message: bytes, signature: str, signer: str
+):
+    """
+    Test the application app_id on a given message, signature, signer
+    Check the logged value by the application matches the signer
+    """
+    addr = call_application_eth_ecdsa_recover(
+        acct,
+        app_id,
+        message,
+        bytes.fromhex(signature)
+    )
+    print("Address recovered (without checksum): {}".format(addr.hex()))
+    print("Address expected  (with checksum):    {}".format(signer))
+    if signer.lower() == addr.hex():  # need to lowercase to remove checksum
+        print("  Success")
+    else:
+        print("  Fail")
+    print()
+    return addr
+
+
+def demo():
+    # Create acct
+    acct = get_accounts()[1]
+    addr, pk = acct
+    print("Using account {}".format(addr))
+
+    # Read in the json contract description and create a Contract object
+    try:
+        # Create app
+        app_id = create_app(
+            client, addr, pk, get_approval=get_approval, get_clear=get_clear
+        )
+        app_addr = logic.get_application_address(app_id)
+        print("Created App with id: {} and address {}".format(app_id, app_addr))
+
+        # Pay the app address so we can execute calls
+        sp = client.suggested_params()
+        ptxn = PaymentTxn(addr, sp, app_addr, int(1e9))
+        stxn = ptxn.sign(pk)
+        client.send_transaction(stxn)
+
+        # Normally here we'd like to wait for this transaciton to take place
+        # However, in a sandbox environment, this is not necessary
+        # so we cheat to go faster
+        # In real life, uncomment the two lines below
+
+        # txid = stxn.transaction.get_txid()
+        # wait_for_confirmation(client, txid, 4)
+
+        # Now making the real calls
+
+        # The hash and signature we want to check
+        # taken directly from
+        # https://github.com/OpenZeppelin/openzeppelin-contracts/blob/faf5820f0331c59c93b0dca3e08f3456c94d8982/test/utils/cryptography/ECDSA.test.js#L111
+
+        # First one is v0 (recovery ID = 0/27)
+        message = b"OpenZeppelin"
+        signature = "5d99b6f7f6d1f73d1a26497f2b1c89b24c0993913f86e9a2d02cd69887d9c94f3c880358579d811b21dd1b7fd9bb01c1d81d10e69f0384e675c32b39643be8921b"
+        signer = "2cc1166f6212628A0deEf2B33BEFB2187D35b86c"
+        test_application_eth_ecdsa_recover(acct, app_id, message, signature, signer)
+
+        # Second one is v1 (recovery ID = 1/28)
+        message = b"OpenZeppelin"
+        signature = "331fe75a821c982f9127538858900d87d3ec1f9f737338ad67cad133fa48feff48e6fa0c18abc62e42820f05943e47af3e9fbe306ce74d64094bdf1691ee53e01c"
+        signer = "1E318623aB09Fe6de3C9b8672098464Aeda9100E"
+        test_application_eth_ecdsa_recover(acct, app_id, message, signature, signer)
+
+    except:
+        print("Fail :(\n", file=sys.stderr)
+        traceback.print_exc()
+    finally:
+        print("Cleaning up")
+        delete_app(client, app_id, addr, pk)
+
+
+def get_logs_recursive(results: list[any]):
+    logs = []
+    for res in results:
+        if "logs" in res:
+            for l in [base64.b64decode(log) for log in res["logs"]]:
+                logs.append(l)
+        if "inner-txns" in res:
+            logs.extend(get_logs_recursive(res["inner-txns"]))
+
+    return logs
+
+
+if __name__ == "__main__":
+    demo()

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,13 +9,13 @@ networkx==2.6.3
 packaging==21.3
 pluggy==1.0.0
 py==1.11.0
-py-algorand-sdk==1.9.0
+py-algorand-sdk==1.15.0
 pycparser==2.21
 pycryptodomex==3.12.0
 pydantic==1.9.0
 PyNaCl==1.5.0
 pyparsing==3.0.6
--e git+https://github.com/algorand/pyteal.git@master#egg=pyteal
+pyteal==0.13.0
 -e git+https://github.com/algorand/pyteal-utils.git@main#egg=pyteal_utils
 pytest==6.2.5
 pytest-depends==1.0.1


### PR DESCRIPTION
This example shows how to get the equivalent of OpenZeppelin ECDSA.recover for long 65-byte Ethereum signatures
(https://docs.openzeppelin.com/contracts/2.x/api/cryptography#ECDSA-recover-bytes32-bytes-)
Short 64-byte Ethereum signatures require some changes to the code.
This can be used in applications requiring some compatibility with Ethereum.
For pure Algorand applications, ed25519 is strongly recommended instead of ecdsa.

Like the other examples, this example has *NOT* been audited and *MUST NOT* be used in production code.
If this example is used in production code, a full audit is necessary due to the nature of this example
(use of cryptography).

Changes:
* adding the example
* updating requirements.md to use a released version of pyteal
  (now that this is possible)
* updating the README to indicate that sandbox can be in
  release mode now